### PR TITLE
Remove debug style

### DIFF
--- a/scss/material-theme.scss
+++ b/scss/material-theme.scss
@@ -2360,7 +2360,3 @@
     margin: 0 0 64px;
   }
   
-  h2 {
-    color: red !important;
-  }
-  


### PR DESCRIPTION
This style declaration was originally added to ensure the styles were applied and working, but it shouldn't be a part of the theme.