### PR TITLE
Fixes mat ripple styles

### DIFF
--- a/scss/material-theme.scss
+++ b/scss/material-theme.scss
@@ -1,14 +1,14 @@
-.mat-ripple {
+::ng-deep .mat-ripple {
     overflow: hidden;
     position: relative;
   }
-  .mat-ripple:not(:empty) {
+  ::ng-deep .mat-ripple:not(:empty) {
     transform: translateZ(0);
   }
-  .mat-ripple.mat-ripple-unbounded {
+  ::ng-deep .mat-ripple.mat-ripple-unbounded {
     overflow: visible;
   }
-  .mat-ripple-element {
+  ::ng-deep .mat-ripple-element {
     position: absolute;
     border-radius: 50%;
     pointer-events: none;


### PR DESCRIPTION
Fixes broken mat ripple styles.

Before:
![BrokenMatRipple](https://github.com/user-attachments/assets/a67f28ac-b139-4980-93a9-5d6fb9c954e7)

After:
![WorkingMatRipple](https://github.com/user-attachments/assets/d50c3720-1909-4ef6-b903-e936f4afab9b)

