### PR TITLE
Update meta

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
-Copyright (c) 2024 Rocketfarm AS
+Copyright (c) 2025 Google LLC.
+Copyright (c) 2025 Rocketfarm AS
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
   },
   "author": "Rocketfarm AS",
   "license": "MIT",
-  "description": "",
+  "description": "Use Google's Material Theme in your URCapX frontend contribution.",
+  "repository": "github:RocketfarmAS/psx_material-theme",
+  "homepage": "https://rocketfarm.no/",
   "devDependencies": {
     "prettier": "3.4.2"
   }


### PR DESCRIPTION
Adds a few fields which will make our [page on `npm`](https://www.npmjs.com/package/polyscope-x-material-theme) contain a bit more useful information.

Also adds back Google as the original copyright holder on the MIT license, which seems to be the usual practice.